### PR TITLE
 Added 'thresholds' Table for Sensor Warning Values

### DIFF
--- a/db/init.sql
+++ b/db/init.sql
@@ -1,17 +1,3 @@
-CREATE TABLE IF NOT EXISTS devices (
-    id SERIAL PRIMARY KEY,
-    name VARCHAR(100) NOT NULL,
-    location VARCHAR(100),
-    type VARCHAR(50)
-);
-
-COMMENT ON TABLE devices IS 'Table for storing device information';
-COMMENT ON COLUMN devices.id IS 'Unique identifier for the device';
-COMMENT ON COLUMN devices.name IS 'Name of the device';
-COMMENT ON COLUMN devices.location IS 'Location where the device is installed';
-COMMENT ON COLUMN devices.type IS 'Type of the device (e.g., sensor, actuator)
-
-
 CREATE TABLE IF NOT EXISTS sensor_data (
     device_id INT NOT NULL,
     timestamp TIMESTAMPTZ NOT NULL,
@@ -20,12 +6,6 @@ CREATE TABLE IF NOT EXISTS sensor_data (
     pollen INT,
     particulate_matter INT,
     PRIMARY KEY (device_id, timestamp)
-
-    CONSTRAINT fk_sensor_device
-        FOREIGN KEY (device_id)
-        REFERENCES devices(id)
-        ON DELETE CASCADE
-        ON UPDATE CASCADE
 );
 
 COMMENT ON TABLE sensor_data IS 'Table for storing sensor data from devices';
@@ -35,33 +15,30 @@ COMMENT ON COLUMN sensor_data.temperature IS 'Temperature reading from the devic
 COMMENT ON COLUMN sensor_data.humidity IS 'Humidity reading from the device';
 COMMENT ON COLUMN sensor_data.pollen IS 'Pollen count reading from the device';
 COMMENT ON COLUMN sensor_data.particulate_matter IS 'Particulate matter reading from the device';
-COMMENT ON TABLE device_thresholds IS 'Table for storing thresholds for devices';
 
 -- change table to hypertable
 SELECT create_hypertable('sensor_data', 'timestamp', if_not_exists => TRUE);
 
 CREATE TABLE IF NOT EXISTS device_thresholds (
-    device_id INT NOT NULL PRIMARY KEY,
+    id INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
     temperature_min DECIMAL(5, 2),
     temperature_max DECIMAL(5, 2),
     humidity_min DECIMAL(5, 2),
     humidity_max DECIMAL(5, 2),
+    pollen_min INT,
     pollen_max INT,
+    particulate_matter_min INT,
     particulate_matter_max INT,
-    last_updated TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-    
-    CONSTRAINT fk_threshold_device
-        FOREIGN KEY (device_id)
-        REFERENCES devices(id)
-        ON DELETE CASCADE
-        ON UPDATE CASCADE
+    last_updated TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
 );
 
-COMMENT ON COLUMN device_thresholds.device_id IS 'ID of the device for which thresholds are set';
+COMMENT ON TABLE device_thresholds IS 'Table for storing thresholds for devices';
+COMMENT ON COLUMN device_thresholds.id IS 'Unique identifier for the device thresholds';
 COMMENT ON COLUMN device_thresholds.temperature_min IS 'Minimum temperature threshold for the device';
 COMMENT ON COLUMN device_thresholds.temperature_max IS 'Maximum temperature threshold for the device';
 COMMENT ON COLUMN device_thresholds.humidity_min IS 'Minimum humidity threshold for the device';
 COMMENT ON COLUMN device_thresholds.humidity_max IS 'Maximum humidity threshold for the device';
+COMMENT ON COLUMN device_thresholds.pollen_min IS 'Minimum pollen count threshold for the device';
 COMMENT ON COLUMN device_thresholds.pollen_max IS 'Maximum pollen count threshold for the device';
 COMMENT ON COLUMN device_thresholds.particulate_matter_max IS 'Maximum particulate matter threshold for the device';
 COMMENT ON COLUMN device_thresholds.last_updated IS 'Timestamp of the last update to the thresholds';

--- a/db/init.sql
+++ b/db/init.sql
@@ -1,3 +1,17 @@
+CREATE TABLE IF NOT EXISTS devices (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    location VARCHAR(100),
+    type VARCHAR(50)
+);
+
+COMMENT ON TABLE devices IS 'Table for storing device information';
+COMMENT ON COLUMN devices.id IS 'Unique identifier for the device';
+COMMENT ON COLUMN devices.name IS 'Name of the device';
+COMMENT ON COLUMN devices.location IS 'Location where the device is installed';
+COMMENT ON COLUMN devices.type IS 'Type of the device (e.g., sensor, actuator)
+
+
 CREATE TABLE IF NOT EXISTS sensor_data (
     device_id INT NOT NULL,
     timestamp TIMESTAMPTZ NOT NULL,
@@ -6,7 +20,48 @@ CREATE TABLE IF NOT EXISTS sensor_data (
     pollen INT,
     particulate_matter INT,
     PRIMARY KEY (device_id, timestamp)
+
+    CONSTRAINT fk_sensor_device
+        FOREIGN KEY (device_id)
+        REFERENCES devices(id)
+        ON DELETE CASCADE
+        ON UPDATE CASCADE
 );
+
+COMMENT ON TABLE sensor_data IS 'Table for storing sensor data from devices';
+COMMENT ON COLUMN sensor_data.device_id IS 'ID of the device that collected the data';
+COMMENT ON COLUMN sensor_data.timestamp IS 'Timestamp of the data collection';
+COMMENT ON COLUMN sensor_data.temperature IS 'Temperature reading from the device';
+COMMENT ON COLUMN sensor_data.humidity IS 'Humidity reading from the device';
+COMMENT ON COLUMN sensor_data.pollen IS 'Pollen count reading from the device';
+COMMENT ON COLUMN sensor_data.particulate_matter IS 'Particulate matter reading from the device';
+COMMENT ON TABLE device_thresholds IS 'Table for storing thresholds for devices';
 
 -- change table to hypertable
 SELECT create_hypertable('sensor_data', 'timestamp', if_not_exists => TRUE);
+
+CREATE TABLE IF NOT EXISTS device_thresholds (
+    device_id INT NOT NULL PRIMARY KEY,
+    temperature_min DECIMAL(5, 2),
+    temperature_max DECIMAL(5, 2),
+    humidity_min DECIMAL(5, 2),
+    humidity_max DECIMAL(5, 2),
+    pollen_max INT,
+    particulate_matter_max INT,
+    last_updated TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    
+    CONSTRAINT fk_threshold_device
+        FOREIGN KEY (device_id)
+        REFERENCES devices(id)
+        ON DELETE CASCADE
+        ON UPDATE CASCADE
+);
+
+COMMENT ON COLUMN device_thresholds.device_id IS 'ID of the device for which thresholds are set';
+COMMENT ON COLUMN device_thresholds.temperature_min IS 'Minimum temperature threshold for the device';
+COMMENT ON COLUMN device_thresholds.temperature_max IS 'Maximum temperature threshold for the device';
+COMMENT ON COLUMN device_thresholds.humidity_min IS 'Minimum humidity threshold for the device';
+COMMENT ON COLUMN device_thresholds.humidity_max IS 'Maximum humidity threshold for the device';
+COMMENT ON COLUMN device_thresholds.pollen_max IS 'Maximum pollen count threshold for the device';
+COMMENT ON COLUMN device_thresholds.particulate_matter_max IS 'Maximum particulate matter threshold for the device';
+COMMENT ON COLUMN device_thresholds.last_updated IS 'Timestamp of the last update to the thresholds';

--- a/db/init.sql
+++ b/db/init.sql
@@ -8,37 +8,26 @@ CREATE TABLE IF NOT EXISTS sensor_data (
     PRIMARY KEY (device_id, timestamp)
 );
 
-COMMENT ON TABLE sensor_data IS 'Table for storing sensor data from devices';
-COMMENT ON COLUMN sensor_data.device_id IS 'ID of the device that collected the data';
-COMMENT ON COLUMN sensor_data.timestamp IS 'Timestamp of the data collection';
-COMMENT ON COLUMN sensor_data.temperature IS 'Temperature reading from the device';
-COMMENT ON COLUMN sensor_data.humidity IS 'Humidity reading from the device';
-COMMENT ON COLUMN sensor_data.pollen IS 'Pollen count reading from the device';
-COMMENT ON COLUMN sensor_data.particulate_matter IS 'Particulate matter reading from the device';
-
 -- change table to hypertable
 SELECT create_hypertable('sensor_data', 'timestamp', if_not_exists => TRUE);
 
-CREATE TABLE IF NOT EXISTS device_thresholds (
+CREATE TABLE IF NOT EXISTS thresholds (
     id INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
-    temperature_min DECIMAL(5, 2),
-    temperature_max DECIMAL(5, 2),
-    humidity_min DECIMAL(5, 2),
-    humidity_max DECIMAL(5, 2),
-    pollen_min INT,
-    pollen_max INT,
-    particulate_matter_min INT,
-    particulate_matter_max INT,
+    temperature_min_soft DECIMAL(5, 2),
+    temperature_max_soft DECIMAL(5, 2),
+    temperature_min_hard DECIMAL(5, 2),
+    temperature_max_hard DECIMAL(5, 2),
+    humidity_min_soft DECIMAL(5, 2),
+    humidity_max_soft DECIMAL(5, 2),
+    humidity_min_hard DECIMAL(5, 2),
+    humidity_max_hard DECIMAL(5, 2),
+    pollen_min_soft INT,
+    pollen_max_soft INT,
+    pollen_min_hard INT,
+    pollen_max_hard INT,
+    particulate_matter_min_soft INT,
+    particulate_matter_max_soft INT,
+    particulate_matter_min_hard INT,
+    particulate_matter_max_hard INT,
     last_updated TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
 );
-
-COMMENT ON TABLE device_thresholds IS 'Table for storing thresholds for devices';
-COMMENT ON COLUMN device_thresholds.id IS 'Unique identifier for the device thresholds';
-COMMENT ON COLUMN device_thresholds.temperature_min IS 'Minimum temperature threshold for the device';
-COMMENT ON COLUMN device_thresholds.temperature_max IS 'Maximum temperature threshold for the device';
-COMMENT ON COLUMN device_thresholds.humidity_min IS 'Minimum humidity threshold for the device';
-COMMENT ON COLUMN device_thresholds.humidity_max IS 'Maximum humidity threshold for the device';
-COMMENT ON COLUMN device_thresholds.pollen_min IS 'Minimum pollen count threshold for the device';
-COMMENT ON COLUMN device_thresholds.pollen_max IS 'Maximum pollen count threshold for the device';
-COMMENT ON COLUMN device_thresholds.particulate_matter_max IS 'Maximum particulate matter threshold for the device';
-COMMENT ON COLUMN device_thresholds.last_updated IS 'Timestamp of the last update to the thresholds';

--- a/docs/adr/0009-introduction-of-a-dedicated-devices-table-devices.md
+++ b/docs/adr/0009-introduction-of-a-dedicated-devices-table-devices.md
@@ -1,0 +1,29 @@
+# 9. Introduction of a Dedicated Devices Table (devices)
+
+Date: 2025-07-30
+
+## Status
+
+Accepted
+
+## Context
+
+Currently, sensor data is stored in the sensor_data table, and thresholds for this data are in the device_thresholds table. Both tables include a device_id. There's a need to improve data integrity and ensure that only device_ids that genuinely exist are used. With the current structure, where device_id in sensor_data is part of a composite primary key ((device_id, timestamp)), it's not possible to establish a foreign key from device_thresholds to sensor_data. This leads to potential inconsistencies (e.g., thresholds for non-existent devices) and complicates central device management.
+
+### Alternatives Considered
+**Keeping only two tables:** This simpler approach avoids the overhead of a third table. However, it means the database cannot enforce referential integrity between device_ids in sensor_data and device_thresholds. Data consistency would rely entirely on application-level logic, increasing the risk of orphaned or invalid entries, especially as the system scales or multiple applications interact with the database.
+
+## Decision
+
+We will introduce a third table named devices.
+
+* The devices table will be the unique source for all device_ids in the database.
+* device_id will be the primary key in the devices table.
+* Both the sensor_data and device_thresholds tables will include a foreign key referencing devices.device_id.
+* These foreign keys will be configured with ON DELETE CASCADE and ON UPDATE CASCADE.
+
+## Consequences
+
+* **Database Schema Change:** The database schema will need to be extended with a new table, and existing tables will be updated with foreign keys. This requires a migration strategy if the database is already in production.
+* **Application Logic:** The application logic for creating and deleting devices must be adapted to first create entries in the devices table before sensor data can be sent or thresholds can be set.
+* **Performance:** There will be a minor impact due to additional join operations for queries that require device information, but this is typically offset by indexing and outweighed by the improved data integrity.


### PR DESCRIPTION
This Pull Request introduces a new table named thresholds to the database. This table is designed to store the configured warning and limit values for various sensors (temperature, humidity, pollen, particulate matter).

With this table, we establish the foundation to:

- **Flexible Warnings:** Define "soft" thresholds for minor warnings and "hard" thresholds for critical alarms.
- **Configurability:** Thresholds can be centrally managed in the database and adjusted as needed, without requiring code changes.
- **Extensibility:** The structure is designed to easily accommodate additional sensor types or threshold categories in the future.

The last_updated column helps track when the thresholds were last modified.