### PR TITLE
added sensor availability

### DIFF
--- a/docs/grafana.md
+++ b/docs/grafana.md
@@ -1,12 +1,12 @@
-
 # 📖 Documentation: Sensor Data Monitoring with Grafana & TimescaleDB
 
 ## 1. Overview
 This project provides a monitoring stack for IoT sensor data. It ingests sensor readings via MQTT, stores them in a TimescaleDB (PostgreSQL with time-series extensions), and visualizes data in Grafana.  
 
-The focus of the dashboards is on **availability analysis** – comparing the expected number of sensor messages with the actual count and highlighting data gaps.
+The focus of the dashboards is on **availability analysis** – comparing the expected number of sensor messages with the actual count and highlighting data gaps.  
+Additionally, the system shows **per-sensor availability** (temperature, humidity, pollen, particulate matter) per device.
 
-
+---
 
 ## 2. Data Source Configuration
 Grafana is preconfigured with a PostgreSQL datasource pointing to TimescaleDB.
@@ -31,8 +31,8 @@ datasources:
       timescaledb: true
 ```
 
-- **Datasource name**: `TimescaleDB`
-- **UID**: `timescaledb` (used inside dashboards)
+- **Datasource name**: `TimescaleDB`  
+- **UID**: `timescaledb` (used inside dashboards)  
 - **Authentication**: via environment variables `${DB_USER}` and `${DB_PASSWORD}`
 
 ---
@@ -42,48 +42,52 @@ The `Availability.json` file defines a Grafana dashboard that tracks sensor data
 
 ### Panels
 1. **Expected Values (per device)**  
-   - Query:  
-     ```sql
-     SELECT soll_total AS value 
-     FROM v_totals_since_start_by_device 
-     WHERE device_id = <id>;
-     ```
+   ```sql
+   SELECT expected_total AS value 
+   FROM v_totals_since_start_by_device 
+   WHERE device_id = <id>;
+   ```
    - Shows how many messages *should* have been received since the start.
 
 2. **Actual Values (per device)**  
-   - Query:  
-     ```sql
-     SELECT ist_total AS value 
-     FROM v_totals_since_start_by_device 
-     WHERE device_id = <id>;
-     ```
+   ```sql
+   SELECT actual_total AS value 
+   FROM v_totals_since_start_by_device 
+   WHERE device_id = <id>;
+   ```
    - Displays the number of messages that were actually ingested.
 
 3. **Availability Gauge**  
-   - Query:  
-     ```sql
-     SELECT availability_pct AS value 
-     FROM v_totals_since_start_by_device 
-     WHERE device_id = <id>;
-     ```
+   ```sql
+   SELECT availability_pct AS value 
+   FROM v_totals_since_start_by_device 
+   WHERE device_id = <id>;
+   ```
    - Visualizes the percentage of received messages (`actual / expected`).  
    - Thresholds:  
      - <70% = red  
      - ≥70% = green  
 
-4. **Gap Table**  
-   - Query:  
-     ```sql
-     SELECT device_id, gap_start, gap_end, gap_duration 
-     FROM v_sensor_gaps 
-     ORDER BY device_id, gap_start;
-     ```
-   - Lists all detected communication gaps longer than 10 minutes.
+4. **Per-Sensor Table (per device & sensor)**  
+   ```sql
+   SELECT device_id, sensor, expected_total, actual_count, availability_pct
+   FROM v_counts_since_start_by_device_and_sensor
+   ORDER BY device_id, sensor;
+   ```
+   - Shows expected vs. actual counts and availability percentage for each individual sensor column.  
+
+5. **Gap Table**  
+   ```sql
+   SELECT device_id, gap_start, gap_end, gap_duration 
+   FROM v_sensor_gaps 
+   ORDER BY device_id, gap_start;
+   ```
+   - Lists all detected communication gaps longer than 10 minutes.  
    - `gap_duration` is displayed in seconds.
 
 ### Layout
-- Top row: Device 1 – Expected, Actual, Availability  
-- Second row: Device 2 – Expected, Actual, Availability  
+- Top rows: Device 1 & Device 2 – Expected, Actual, Availability  
+- Middle: Per-Sensor availability table  
 - Bottom: Table with gap events across all devices  
 
 ---
@@ -92,10 +96,13 @@ The `Availability.json` file defines a Grafana dashboard that tracks sensor data
 The dashboard depends on the following **database views** (must be created in SQL scripts):
 
 - **`v_totals_since_start_by_device`**  
-  Provides `soll_total`, `ist_total`, and `availability_pct` per device.  
-  - `soll_total`: Expected number of rows based on device frequency.  
-  - `ist_total`: Count of rows actually inserted.  
-  - `availability_pct`: `(ist_total / soll_total) * 100`.
+  Provides `expected_total`, `actual_total`, and `availability_pct` per device.  
+  - `expected_total`: Expected number of rows based on device frequency.  
+  - `actual_total`: Count of rows actually inserted.  
+  - `availability_pct`: `(actual_total / expected_total) * 100`.
+
+- **`v_counts_since_start_by_device_and_sensor`**  
+  Provides `expected_total`, `actual_count`, and `availability_pct` per sensor column (temperature, humidity, pollen, particulate_matter).  
 
 - **`v_sensor_gaps`**  
   Lists communication gaps longer than 10 minutes with start/end timestamps and duration.
@@ -109,10 +116,9 @@ The dashboard depends on the following **database views** (must be created in SQ
    ```
 2. Open Grafana: [http://localhost:3003](http://localhost:3003)  
 3. Open the dashboard **“Sensor Availability”**.  
-4. Observe per-device availability and data gaps.
+4. Observe per-device and per-sensor availability and data gaps.
 
 ---
-
 
 ## 6. Maintenance Notes
 - Ensure TimescaleDB hypertables and indexes are created:
@@ -120,9 +126,7 @@ The dashboard depends on the following **database views** (must be created in SQ
   SELECT create_hypertable('sensor_data', 'ts', if_not_exists => TRUE);
   CREATE INDEX IF NOT EXISTS idx_sensor_ts ON sensor_data (ts DESC);
   ```
-- Use `pgAdmin` at [http://localhost:5480](http://localhost:5480) for manual queries.
+- Use `pgAdmin` at [http://localhost:5480](http://localhost:5480) for manual queries.  
 - Check service health in **Uptime Kuma** at [http://localhost:3002](http://localhost:3002).
 
 ---
-
-

--- a/grafana/provisioning/dashboards/Avalability.json
+++ b/grafana/provisioning/dashboards/Avalability.json
@@ -4,76 +4,155 @@
   "schemaVersion": 39,
   "version": 1,
   "refresh": "30s",
-  "time": { "from": "now-90d", "to": "now" },
+  "time": {
+    "from": "now-90d",
+    "to": "now"
+  },
   "panels": [
     {
       "id": 101,
       "type": "stat",
       "title": "Device 1 – Expected",
-      "gridPos": { "x": 0, "y": 0, "w": 8, "h": 5 },
-      "datasource": { "type": "postgres", "uid": "timescaledb" },
-      "targets": [{
-        "refId": "A",
-        "datasource": { "type": "postgres", "uid": "timescaledb" },
-        "format": "table",
-        "rawSql": "SELECT soll_total AS value FROM v_totals_since_start_by_device WHERE device_id = 1;"
-      }],
+      "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 8,
+        "h": 5
+      },
+      "datasource": {
+        "type": "postgres",
+        "uid": "timescaledb"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "postgres",
+            "uid": "timescaledb"
+          },
+          "format": "table",
+          "rawSql": "SELECT expected_total AS value FROM v_totals_since_start_by_device WHERE device_id = 1;"
+        }
+      ],
       "options": {
         "colorMode": "none",
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "horizontal",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "value"
       },
-      "fieldConfig": { "defaults": { "unit": "none" }, "overrides": [] }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none"
+        },
+        "overrides": []
+      }
     },
     {
       "id": 102,
       "type": "stat",
       "title": "Device 1 – Actual",
-      "gridPos": { "x": 8, "y": 0, "w": 8, "h": 5 },
-      "datasource": { "type": "postgres", "uid": "timescaledb" },
-      "targets": [{
-        "refId": "A",
-        "datasource": { "type": "postgres", "uid": "timescaledb" },
-        "format": "table",
-        "rawSql": "SELECT ist_total  AS value FROM v_totals_since_start_by_device WHERE device_id = 1;"
-      }],
+      "gridPos": {
+        "x": 8,
+        "y": 0,
+        "w": 8,
+        "h": 5
+      },
+      "datasource": {
+        "type": "postgres",
+        "uid": "timescaledb"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "postgres",
+            "uid": "timescaledb"
+          },
+          "format": "table",
+          "rawSql": "SELECT actual_total  AS value FROM v_totals_since_start_by_device WHERE device_id = 1;"
+        }
+      ],
       "options": {
         "colorMode": "none",
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "horizontal",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "value"
       },
-      "fieldConfig": { "defaults": { "unit": "none" }, "overrides": [] }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none"
+        },
+        "overrides": []
+      }
     },
     {
       "id": 103,
       "type": "gauge",
       "title": "Device 1 – Availability",
-      "gridPos": { "x": 16, "y": 0, "w": 8, "h": 5 },
-      "datasource": { "type": "postgres", "uid": "timescaledb" },
-      "targets": [{
-        "refId": "A",
-        "datasource": { "type": "postgres", "uid": "timescaledb" },
-        "format": "table",
-        "rawSql": "SELECT availability_pct AS value FROM v_totals_since_start_by_device WHERE device_id = 1;"
-      }],
+      "gridPos": {
+        "x": 16,
+        "y": 0,
+        "w": 8,
+        "h": 5
+      },
+      "datasource": {
+        "type": "postgres",
+        "uid": "timescaledb"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "postgres",
+            "uid": "timescaledb"
+          },
+          "format": "table",
+          "rawSql": "SELECT availability_pct AS value FROM v_totals_since_start_by_device WHERE device_id = 1;"
+        }
+      ],
       "options": {
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "showThresholdLabels": false,
         "showThresholdMarkers": true
       },
       "fieldConfig": {
         "defaults": {
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [
-            { "color": "red", "value": null },
-            { "color": "green", "value": 70 }
-          ]},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 70
+              }
+            ]
+          },
           "unit": "percent"
         },
         "overrides": []
@@ -83,70 +162,146 @@
       "id": 201,
       "type": "stat",
       "title": "Device 2 – Expected",
-      "gridPos": { "x": 0, "y": 5, "w": 8, "h": 5 },
-      "datasource": { "type": "postgres", "uid": "timescaledb" },
-      "targets": [{
-        "refId": "A",
-        "datasource": { "type": "postgres", "uid": "timescaledb" },
-        "format": "table",
-        "rawSql": "SELECT soll_total AS value FROM v_totals_since_start_by_device WHERE device_id = 2;"
-      }],
+      "gridPos": {
+        "x": 0,
+        "y": 5,
+        "w": 8,
+        "h": 5
+      },
+      "datasource": {
+        "type": "postgres",
+        "uid": "timescaledb"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "postgres",
+            "uid": "timescaledb"
+          },
+          "format": "table",
+          "rawSql": "SELECT expected_total AS value FROM v_totals_since_start_by_device WHERE device_id = 2;"
+        }
+      ],
       "options": {
         "colorMode": "none",
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "horizontal",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "value"
       },
-      "fieldConfig": { "defaults": { "unit": "none" }, "overrides": [] }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none"
+        },
+        "overrides": []
+      }
     },
     {
       "id": 202,
       "type": "stat",
       "title": "Device 2 – Actual",
-      "gridPos": { "x": 8, "y": 5, "w": 8, "h": 5 },
-      "datasource": { "type": "postgres", "uid": "timescaledb" },
-      "targets": [{
-        "refId": "A",
-        "datasource": { "type": "postgres", "uid": "timescaledb" },
-        "format": "table",
-        "rawSql": "SELECT ist_total  AS value FROM v_totals_since_start_by_device WHERE device_id = 2;"
-      }],
+      "gridPos": {
+        "x": 8,
+        "y": 5,
+        "w": 8,
+        "h": 5
+      },
+      "datasource": {
+        "type": "postgres",
+        "uid": "timescaledb"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "postgres",
+            "uid": "timescaledb"
+          },
+          "format": "table",
+          "rawSql": "SELECT actual_total  AS value FROM v_totals_since_start_by_device WHERE device_id = 2;"
+        }
+      ],
       "options": {
         "colorMode": "none",
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "horizontal",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "value"
       },
-      "fieldConfig": { "defaults": { "unit": "none" }, "overrides": [] }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none"
+        },
+        "overrides": []
+      }
     },
     {
       "id": 203,
       "type": "gauge",
       "title": "Device 2 – Availability",
-      "gridPos": { "x": 16, "y": 5, "w": 8, "h": 5 },
-      "datasource": { "type": "postgres", "uid": "timescaledb" },
-      "targets": [{
-        "refId": "A",
-        "datasource": { "type": "postgres", "uid": "timescaledb" },
-        "format": "table",
-        "rawSql": "SELECT availability_pct AS value FROM v_totals_since_start_by_device WHERE device_id = 2;"
-      }],
+      "gridPos": {
+        "x": 16,
+        "y": 5,
+        "w": 8,
+        "h": 5
+      },
+      "datasource": {
+        "type": "postgres",
+        "uid": "timescaledb"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "postgres",
+            "uid": "timescaledb"
+          },
+          "format": "table",
+          "rawSql": "SELECT availability_pct AS value FROM v_totals_since_start_by_device WHERE device_id = 2;"
+        }
+      ],
       "options": {
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "showThresholdLabels": false,
         "showThresholdMarkers": true
       },
       "fieldConfig": {
         "defaults": {
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [
-            { "color": "red", "value": null },
-            { "color": "green", "value": 70 }
-          ]},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 70
+              }
+            ]
+          },
           "unit": "percent"
         },
         "overrides": []
@@ -156,21 +311,98 @@
       "id": 301,
       "type": "table",
       "title": "Gaps > 10 minutes",
-      "gridPos": { "x": 0, "y": 10, "w": 24, "h": 12 },
-      "datasource": { "type": "postgres", "uid": "timescaledb" },
-      "targets": [{
-        "refId": "A",
-        "datasource": { "type": "postgres", "uid": "timescaledb" },
-        "format": "table",
-        "rawSql": "SELECT device_id, gap_start, gap_end, gap_duration FROM v_sensor_gaps ORDER BY device_id, gap_start;"
-      }],
-      "options": { "showHeader": true, "footer": { "show": false }, "cellHeight": "sm" },
+      "gridPos": {
+        "x": 0,
+        "y": 10,
+        "w": 24,
+        "h": 12
+      },
+      "datasource": {
+        "type": "postgres",
+        "uid": "timescaledb"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "postgres",
+            "uid": "timescaledb"
+          },
+          "format": "table",
+          "rawSql": "SELECT device_id, gap_start, gap_end, gap_duration FROM v_sensor_gaps ORDER BY device_id, gap_start;"
+        }
+      ],
+      "options": {
+        "showHeader": true,
+        "footer": {
+          "show": false
+        },
+        "cellHeight": "sm"
+      },
       "fieldConfig": {
         "defaults": {},
         "overrides": [
           {
-            "matcher": { "id": "byName", "options": "gap_duration" },
-            "properties": [{ "id": "unit", "value": "s" }]
+            "matcher": {
+              "id": "byName",
+              "options": "gap_duration"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": 401,
+      "type": "table",
+      "title": "Per Sensor – Counts & Availability",
+      "gridPos": {
+        "x": 0,
+        "y": 22,
+        "w": 24,
+        "h": 12
+      },
+      "datasource": {
+        "type": "postgres",
+        "uid": "timescaledb"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "postgres",
+            "uid": "timescaledb"
+          },
+          "format": "table",
+          "rawSql": "SELECT\n  device_id,\n  sensor,\n  expected_total,\n  actual_count,\n  availability_pct\nFROM v_counts_since_start_by_device_and_sensor\nORDER BY device_id, sensor;"
+        }
+      ],
+      "options": {
+        "showHeader": true,
+        "footer": {
+          "show": false
+        },
+        "cellHeight": "sm"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "availability_pct"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percent"
+              }
+            ]
           }
         ]
       }

--- a/grafana/provisioning/dashboards/logging-overview.json
+++ b/grafana/provisioning/dashboards/logging-overview.json
@@ -26,7 +26,8 @@
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "fixed", "fixedColor": "text" },
-          "thresholds": { "mode": "absolute", "steps": [ { "color": "text", "value": null } ] }
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "text", "value": null } ] },
+          "noValue": "0"
         },
         "overrides": []
       }
@@ -50,7 +51,8 @@
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "fixed", "fixedColor": "text" },
-          "thresholds": { "mode": "absolute", "steps": [ { "color": "text", "value": null } ] }
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "text", "value": null } ] },
+          "noValue": "0"
         },
         "overrides": []
       }


### PR DESCRIPTION
Changes introduced:
Renamed metrics from Soll / Ist ➝ Expected / Actual for clarity and consistency.
Added per-sensor availability view (v_counts_since_start_by_device_and_sensor) to measure counts and availability for each sensor (temperature, humidity, pollen, particulate matter).
Extended Grafana dashboard:
Updated queries to use expected_total and actual_total.
Added a new per-sensor availability table panel.
Improved documentation (README.md) with updated examples and usage instructions.
Ensured that missing data points return 0 instead of “No data”.