### PR TITLE
Fix Docker build context path for sensor exporter in GitHub Actions

### DIFF
--- a/.github/workflows/docker-ghcr.yml
+++ b/.github/workflows/docker-ghcr.yml
@@ -33,5 +33,5 @@ jobs:
 
       - name: Build and push sensor exporter image
         run: |
-          docker build -t ghcr.io/geroldj/altbauvsneubau/sensor-exporter:latest -f ./sensor-exporter/Dockerfile ./sensor-exporter
+          docker build -t ghcr.io/geroldj/altbauvsneubau/sensor-exporter:latest -f ./sensor-exporter/Dockerfile .
           docker push ghcr.io/geroldj/altbauvsneubau/sensor-exporter:latest


### PR DESCRIPTION
Correct the Docker build context path in the GitHub Actions workflow to ensure the sensor exporter image builds successfully.