### PR TITLE
Change log level for negative_delay in exporter

### DIFF
--- a/sensor-exporter/exporter.py
+++ b/sensor-exporter/exporter.py
@@ -118,7 +118,7 @@ if __name__ == '__main__':
             delay = (now - ts).total_seconds()
             if delay < 0:
                 log_event(
-                    logger, "WARNING", "negative_delay",
+                    logger, "INFO", "negative_delay",
                     device_id=device_id,
                     sensor_type=sensor_type,
                     delay=delay,


### PR DESCRIPTION
Adjust the log level from WARNING to INFO for negative_delay events in the exporter to improve log clarity.